### PR TITLE
お気に入りランキングの削除した箇所の再アップロード

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,6 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <h1>質問一覧</h1>
+    <%= link_to "お気に入り一覧", favorites_path %>
     <% @questions.each do |question| %>
         <p>タイトル:<%= question.title %></p>
         <p>本文:<%= question.content %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,4 +15,5 @@ Rails.application.routes.draw do
   resources :tags, only: [:index, :show]
 
   root 'tops#index'
+  resources :favorites, only: [:index]
 end


### PR DESCRIPTION
お気に入りランキング一覧のルーティング削除によるエラーを修正しました。
routes.rbの設定とお気に入りランキングのリンクを再アップロードしています。
確認よろしくお願いします。

 app/views/questions/index.html.erb
 config/routes.rb