### PR TITLE
マイページの質問一覧にリンクを付与/担当ページのレイアウトを揃える

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,3 +14,7 @@
  *= require_tree .
  *= require_self
  */
+ ul {
+   padding: 0;
+   list-style-type: none;
+ }

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -6,3 +6,40 @@
     width: 150px;
     height: 150px;
 }
+
+#users {
+  .profile {
+    &::after {
+      content: '.';
+      height: 0;
+      font-size: 0;
+      display: block;
+      clear: both;
+    }
+    .profile-img {
+      float: left;
+      margin-right: 20px;
+      img {
+          width: 100px;
+          height: 100px;
+        &:hover {
+          opacity: 0.5;
+        }
+      }
+    }
+    .profile-text {
+      float: left;
+      .name {
+        font-size: 20px;
+      }
+    }
+  }
+}
+
+#tab1 .profile {
+  margin: 20px 0;
+}
+
+#tab2 {
+  margin-top: 30px;
+}

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,6 +5,7 @@ class FavoritesController < ApplicationController
     #お気に入り数の多いものから上位20件を取得
     @favorites = Favorite.group(:question_id).order('count_all desc').limit(20).count
     @questions = Question.where(id: [@favorites.keys])
+    @users = User.where(id: [@favorites.keys])
   end
 
   def create #お気に入り追加アクション

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,14 +1,17 @@
-<h1>お気に入りランキング</h1>
-<ul>
-  <% @favorites.each do |favorite| %>
-    <li>
-      【★ <%= favorite[1] %>つ】
-      <%= link_to question_path(@questions.find(favorite[0]).id) do %>
-      <%= @questions.find(favorite[0]).title %>
+<div class="container">
+  <div class="col-md-6 col-md-offset-3 col-sm-10 col-sm-offset-1">
+    <h1>お気に入りランキング</h1>
+    <ul>
+      <% @favorites.each do |favorite| %>
+        <li>
+          <hr>
+          <%= link_to question_path(@questions.find(favorite[0]).id) do %>
+          <%= @questions.find(favorite[0]).title %>
+          <% end %>
+          【<%= favorite[1] %>票】<br>
+          内容：<%= @questions.find(favorite[0]).content %>
+        </li>
       <% end %>
-      <br>
-      内容：<%= @questions.find(favorite[0]).content %>
-      <hr>
-    </li>
-  <% end %>
-</ul>
+    </ul>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,15 +1,27 @@
-<div class="content-flued">  
-<h1>ユーザ一覧ページ</h1>
-<ul class="row">
-  <% @users.each do |user| %>
-  <li class="col-md-3 col-sm-3 col-xs-4">
-    <div class="profile">
-      <%= link_to user_path(user.id) do %>
-      <%= profile_img(user) if profile_img(user) %>
-      <% end %>
-    </div>
-    <%= user.name %>
-  </li>
-  <% end %>
-</ul>
+<div class="content">
+  <div class="col-md-6 col-md-offset-3 col-sm-10 col-sm-offset-1">
+  <h1>ユーザ一覧ページ</h1>
+  <ul id="users">
+    <% @users.each do |user| %>
+    <li>
+      <hr>
+      <div class="profile">
+        <div class="profile-img">
+          <%= link_to user_path(user.id) do %>
+          <%= profile_img(user) if profile_img(user) %>
+          <% end %>
+        </div>
+        <div class="profile-text">
+          <div class="name">
+            <%= link_to user_path(user.id) do %>
+            <%= user.name %>さん
+            <% end %>
+          </div>
+          <div class="text"><%= user.profile %></div>
+        </div>
+      </div>
+    </li>
+    <% end %>
+  </ul>
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -61,10 +61,10 @@
               <li>
                 <hr>
                 <p><%= answer.created_at.strftime("%Y.%m.%d") %>に回答しました</p>
-                <p>回答した質問:<%= @answer_questions.find(answer.question_id).title %></p>
                 <%= link_to question_path(answer.question_id) do %>
-                <p>回答した内容:<%= answer.content %></p>
+                <p>回答した質問:<%= @answer_questions.find(answer.question_id).title %></p>
                 <% end %>
+                <p>回答した内容:<%= answer.content %></p>
               </li>
               <% end %>
             </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,79 +1,89 @@
-<h1><%= @user.name %>さんのページです</h1>
-<div>
-  <!--タブのボタン部分-->
-  <ul class="nav nav-tabs">
-    <li class="nav-item active">
-      <a href="#tab1" class="nav-link" data-toggle="tab">プロフィール</a>
-    </li>
-    <li class="nav-item">
-      <a href="#tab2" class="nav-link" data-toggle="tab">アクティブ</a>
-    </li>
-  </ul>
-  <!--タブのコンテンツ部分-->
-  <div class="tab-content">
-    <div id="tab1" class="tab-pane active">
-      <%= @user.name %>さんのプロフィール<% if @user.id == current_user.id %>
-      <!-- 自分のページの場合のみ表示 -->
-        [<%= link_to "プロフィール編集", edit_user_registration_path %>]
-      <% end %>
-        <div class="profile"><%= profile_img(@user) if profile_img(@user) %></div>
-        <p><プロフィール><br><%= @user.profile %></p>
-    </div>
-    <div id="tab2" class="tab-pane">
-      <hr>
-      <!--タブのボタン部分-->
-      <ul class="nav nav-tabs">
-        <li class="nav-item active">
-          <a href="#tab2-1" class="nav-link" data-toggle="tab">投稿した質問</a>
-        </li>
-        <li class="nav-item">
-          <a href="#tab2-2" class="nav-link" data-toggle="tab">投稿した回答</a>
-        </li>
-        </li>
-        <li class="nav-item">
-          <a href="#tab2-3" class="nav-link" data-toggle="tab">お気に入り一覧</a>
-        </li>
-      </ul>
-      <!--タブのコンテンツ部分-->
-      <div class="tab-content">
-        <div id="tab2-1" class="tab-pane active">
-          <h4>投稿した質問</h4>
-          <ul>
-            <% @questions.each do |question| %>
-            <li>
-              <hr>
-              <p><%= question.created_at.strftime("%Y.%m.%d") %>に質問しました</p>
-              <p>投稿した質問:<%= question.title %></p>
-              <p>投稿した内容:<%= question.content %></p>
-            </li>
-            <% end %>
-          </ul>
-        </div>
-        <div id="tab2-2" class="tab-pane">
-          <h4>投稿した回答</h4>
-          <ul>
-            <% @answers.each do |answer| %>
-            <li>
-              <hr>
-              <p><%= answer.created_at.strftime("%Y.%m.%d") %>に回答しました</p>
-              <p>回答した質問:<%= @answer_questions.find(answer.question_id).title %></p>
-              <p>回答した内容:<%= answer.content %></p>
-            </li>
-            <% end %>
-          </ul>
-        </div>
-        <div id="tab2-3" class="tab-pane">
-          <h4>お気に入り一覧</h4>
-          <ul>
-            <% @favorites.each do |favorite| %>
-            <li>
-              <hr>
-              <p><%= favorite.created_at.strftime("%Y.%m.%d") %>にお気に入り登録しました</p>
-              <p><%= @favorite_questions.find(favorite.question_id).title %></p>
-              <p><%= @favorite_questions.find(favorite.question_id).content %></p>
-            </li>
-            <% end %>
-          </ul>
+<div class="container">
+  <div class="col-md-6 col-md-offset-3 col-sm-10 col-sm-offset-1">
+    <h1><%= @user.name %>さんのページです</h1>
+    <!--タブのボタン部分-->
+    <ul class="nav nav-tabs">
+      <li class="nav-item active">
+        <a href="#tab1" class="nav-link" data-toggle="tab">プロフィール</a>
+      </li>
+      <li class="nav-item">
+        <a href="#tab2" class="nav-link" data-toggle="tab">アクティブ</a>
+      </li>
+    </ul>
+    <!--タブのコンテンツ部分-->
+    <div class="tab-content">
+      <div id="tab1" class="tab-pane active">
+          <div class="profile"><%= profile_img(@user) if profile_img(@user) %></div>
+          <p>
+            【プロフィール】
+            <% if @user.id == current_user.id %>
+            <!-- 自分のページの場合のみ表示 -->
+            <%= link_to "ユーザー設定", edit_user_registration_path %>
+            <% end %><br>
+            <%= @user.profile %>
+          </p>
+      </div>
+      <div id="tab2" class="tab-pane">
+        <!--タブのボタン部分-->
+        <ul class="nav nav-tabs">
+          <li class="nav-item active">
+            <a href="#tab2-1" class="nav-link" data-toggle="tab">投稿した質問</a>
+          </li>
+          <li class="nav-item">
+            <a href="#tab2-2" class="nav-link" data-toggle="tab">投稿した回答</a>
+          </li>
+          </li>
+          <li class="nav-item">
+            <a href="#tab2-3" class="nav-link" data-toggle="tab">お気に入り一覧</a>
+          </li>
+        </ul>
+        <!--タブのコンテンツ部分-->
+        <div class="tab-content">
+          <div id="tab2-1" class="tab-pane active">
+            <h4>投稿した質問</h4>
+            <ul>
+              <% @questions.each do |question| %>
+              <li>
+                <hr>
+                <p><%= question.created_at.strftime("%Y.%m.%d") %>に質問しました</p>
+                <%= link_to question_path(question.id) do %>
+                <p>投稿した質問:<%= question.title %></p>
+                <% end %>
+                <p>投稿した内容:<%= question.content %></p>
+              </li>
+              <% end %>
+            </ul>
+          </div>
+          <div id="tab2-2" class="tab-pane">
+            <h4>投稿した回答</h4>
+            <ul>
+              <% @answers.each do |answer| %>
+              <li>
+                <hr>
+                <p><%= answer.created_at.strftime("%Y.%m.%d") %>に回答しました</p>
+                <p>回答した質問:<%= @answer_questions.find(answer.question_id).title %></p>
+                <%= link_to question_path(answer.question_id) do %>
+                <p>回答した内容:<%= answer.content %></p>
+                <% end %>
+              </li>
+              <% end %>
+            </ul>
+          </div>
+          <div id="tab2-3" class="tab-pane">
+            <h4>お気に入り一覧</h4>
+            <ul>
+              <% @favorites.each do |favorite| %>
+              <li>
+                <hr>
+                <p><%= favorite.created_at.strftime("%Y.%m.%d") %>にお気に入り登録しました</p>
+                <%= link_to question_path(favorite.question_id) do %>
+                <p><%= @favorite_questions.find(favorite.question_id).title %></p>
+                <% end %>
+                <p><%= @favorite_questions.find(favorite.question_id).content %></p>
+              </li>
+              <% end %>
+            </ul>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
以下対応しました。
確認よろしくお願いします！

マイページの投稿した質問、回答、お気に入り一覧にリンクを追加。

マイページ、人気投稿、ユーザ一覧ページのデザインを全体ページと統一。レイアウトの微調整。